### PR TITLE
Fix syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This contains a collection of actions for using with git:
 In the root directory of your Backstage project:
 
 ```
-yarn add --cwd packages/backend @mdude2314/backstage-plugin-scaffolder-git-actions
+yarn --cwd packages/backend add @mdude2314/backstage-plugin-scaffolder-git-actions
 ```
 
 Add the actions you'd like to the scaffolder:


### PR DESCRIPTION
```bash
yarn add --cwd packages/backend @mdude2314/backstage-plugin-scaffolder-git-actions
Usage Error: The --cwd option is ambiguous when used anywhere else than the very first parameter provided in the command line, before even the command path

$ yarn add [--json] [-F,--fixed] [-E,--exact] [-T,--tilde] [-C,--caret] [-D,--dev] [-P,--peer] [-O,--optional] [--prefer-dev] [-i,--interactive] [--cached] [--mode #0] ...
```